### PR TITLE
Allow use of Aillio R1 winusb driver

### DIFF
--- a/src/artisanlib/aillio.py
+++ b/src/artisanlib/aillio.py
@@ -26,6 +26,9 @@ import usb.util # type: ignore
 
 import array
 
+if system().startswith('Windows'):
+    import libusb_package
+
 #import requests
 #from requests_file import FileAdapter # type: ignore # @UnresolvedImport
 #import json
@@ -124,11 +127,18 @@ class AillioR1:
             return
         if self.usbhandle is not None:
             return
-        self.usbhandle = usb.core.find(idVendor=self.AILLIO_VID,
-                                       idProduct=self.AILLIO_PID)
-        if self.usbhandle is None:
+        if not system().startswith('Windows'):
             self.usbhandle = usb.core.find(idVendor=self.AILLIO_VID,
-                                           idProduct=self.AILLIO_PID_REV3)
+                                           idProduct=self.AILLIO_PID)
+            if self.usbhandle is None:
+                self.usbhandle = usb.core.find(idVendor=self.AILLIO_VID,
+                                               idProduct=self.AILLIO_PID_REV3)
+        else:
+            self.usbhandle = libusb_package.find(idVendor=self.AILLIO_VID,
+                                                 idProduct=self.AILLIO_PID)
+            if self.usbhandle is None:
+                self.usbhandle = libusb_package.find(idVendor=self.AILLIO_VID,
+                                                     idProduct=self.AILLIO_PID_REV3)
         if self.usbhandle is None:
             raise OSError('not found or no permission')
         self.__dbg('device found!')

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -117,3 +117,4 @@ SecretStorage==3.3.3; platform_system=='Linux'
 build==1.0.3; platform_system=='Windows'  # required to build pyinstaller bootloader
 pywin32==306; platform_system=='Windows'
 pyinstaller-versionfile==2.1.1; platform_system=='Windows'
+libusb-package==1.0.26.2; platform_system=='Windows'


### PR DESCRIPTION
Changes windows to use libusb_package which includes the required dlls to allow artisan to connect to R1 without any modification of drivers